### PR TITLE
Initital Input Splits

### DIFF
--- a/IceCapMonitor/pom.xml
+++ b/IceCapMonitor/pom.xml
@@ -26,5 +26,11 @@
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>3.3.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.27.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/IceCapMonitor/src/main/java/edu/csu/icecapmonitor/IceCapMonitorMapReduce.java
+++ b/IceCapMonitor/src/main/java/edu/csu/icecapmonitor/IceCapMonitorMapReduce.java
@@ -26,6 +26,7 @@ public class IceCapMonitorMapReduce extends Configured implements Tool {
         job1.setMapOutputValueClass(Text.class);
         job1.setOutputKeyClass(Text.class);
         job1.setOutputValueClass(Text.class);
+        job1.setInputFormatClass(TarInputFormat.class);
 
         FileInputFormat.addInputPath(job1, new Path(inputDir));
         FileOutputFormat.setOutputPath(job1, new Path(outputDir));

--- a/IceCapMonitor/src/main/java/edu/csu/icecapmonitor/NDSIMapReduce.java
+++ b/IceCapMonitor/src/main/java/edu/csu/icecapmonitor/NDSIMapReduce.java
@@ -2,13 +2,14 @@ package edu.csu.icecapmonitor;
 
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
+import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 
 import java.io.IOException;
 
 public class NDSIMapReduce {
-    public static class NDSIMapper extends Mapper<Text, Text, Text, Text> {
-        public void map(Text key, Text value, Context context) throws IOException, InterruptedException {
+    public static class NDSIMapper extends Mapper<LongWritable, Text, Text, Text> {
+        public void map(LongWritable key, Text value, Context context) throws IOException, InterruptedException {
             // mapper code here
         }
     }

--- a/IceCapMonitor/src/main/java/edu/csu/icecapmonitor/TarInputFormat.java
+++ b/IceCapMonitor/src/main/java/edu/csu/icecapmonitor/TarInputFormat.java
@@ -1,0 +1,43 @@
+package edu.csu.icecapmonitor;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TarInputFormat extends InputFormat<LongWritable, Text> {
+
+    @Override
+    public RecordReader<LongWritable, Text> createRecordReader(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+        return new TarRecordReader();
+    }
+
+    @Override
+    public List getSplits(JobContext context) throws IOException {
+        // In this simple example, each .tar file is treated as a single split.
+        // In a more advanced implementation, you could split large .tar files into smaller pieces.
+        List<FileSplit> splits = new ArrayList<>();
+        FileSystem fs = FileSystem.get(context.getConfiguration());
+        Path inputDir = new Path(context.getConfiguration().get("mapred.input.dir"));
+        FileStatus[] fileStatuses = fs.listStatus(inputDir);
+
+        for (FileStatus fileStatus : fileStatuses) {
+            if (fileStatus.isFile() && fileStatus.getPath().toString().endsWith(".tar")) {
+                splits.add(new FileSplit(fileStatus.getPath(), 0, fileStatus.getLen(), null));
+            }
+        }
+        return splits;
+    }
+}

--- a/IceCapMonitor/src/main/java/edu/csu/icecapmonitor/TarRecordReader.java
+++ b/IceCapMonitor/src/main/java/edu/csu/icecapmonitor/TarRecordReader.java
@@ -1,0 +1,75 @@
+package edu.csu.icecapmonitor;
+
+import java.io.BufferedReader;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.LongWritable;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+
+import java.io.IOException;
+
+
+public class TarRecordReader extends RecordReader<LongWritable, Text> {
+
+    private FSDataInputStream fileIn;
+    private LongWritable currentKey;
+    private Text currentValue;
+    private Path current;
+    private Boolean returned;
+
+    @Override
+    public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+        // Get the file from the split
+        FileSplit fileSplit = (FileSplit) split;
+        current = fileSplit.getPath();
+        returned = false;
+
+        currentKey = new LongWritable();
+        currentValue = new Text();
+        // FileSystem fs = filePath.getFileSystem(context.getConfiguration());
+
+    }
+
+    @Override
+    public boolean nextKeyValue() throws IOException, InterruptedException {
+        if (!returned) {
+            currentValue.set(current.toString());
+            returned = true;
+            return true;
+        } else {
+            return false;
+        }
+            
+    }
+
+    @Override
+    public LongWritable getCurrentKey() {
+        return currentKey;
+    }
+
+    @Override
+    public Text getCurrentValue() {
+        return currentValue;
+    }
+
+    @Override
+    public float getProgress() throws IOException {
+        // Progress can be determined based on the number of entries processed
+        return 0; // Simple example, so we return 0 for now
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,33 @@
+# Print our list of just commands
+default:
+    @just -l
+
+# Run `mvn package`
+compile:
+    cd IceCapMonitor && mvn package
+
+# Create directories and upload input data to hdfs
+upload input:
+    hadoop fs -mkdir -p /IceCapMonitor/input
+    hadoop fs -mkdir -p /IceCapMonitor/output
+    hadoop fs -put -t 5 {{input}} /IceCapMonitor/input
+
+# Delete MapReduce output
+cleanup:
+    hadoop fs -rm -r /IceCapMonitor/output || true
+
+# Compile and run sample dataset locally
+local_sample: compile cleanup
+    hadoop jar IceCapMonitor/target/*.jar edu.csu.icecapmonitor.IceCapMonitorMapReduce /IceCapMonitor/input/Sample_Dataset /IceCapMonitor/output
+
+# Compile and run full dataset locally
+local_full: compile cleanup
+    hadoop jar IceCapMonitor/target/*.jar edu.csu.icecapmonitor.IceCapMonitorMapReduce /IceCapMonitor/input/Full_Dataset /IceCapMonitor/output
+
+# Compile and run sample dataset using yarn
+yarn_sample: compile cleanup
+    hadoop jar IceCapMonitor/target/*.jar edu.csu.icecapmonitor.IceCapMonitorMapReduce -D mapreduce.framework.name=yarn /IceCapMonitor/input/Sample_Dataset /IceCapMonitor/output
+
+# Compile and run full dataset using yarn
+yarn_full: compile cleanup
+    hadoop jar IceCapMonitor/target/*.jar edu.csu.icecapmonitor.IceCapMonitorMapReduce -D mapreduce.framework.name=yarn /IceCapMonitor/input/Full_Dataset /IceCapMonitor/output


### PR DESCRIPTION
Implement a custom input format for working with .tar files, for now it gives each mapper a value with the path to the corresponding tar file but could be expanded to return the data from files inside each tar.